### PR TITLE
Improve connected component props typing - take 2

### DIFF
--- a/test/test_react_connect.tsx
+++ b/test/test_react_connect.tsx
@@ -312,11 +312,13 @@ describe("react bridge: connect() tests", () => {
             return { props };
         });
         console.info(<ConnectedTestComponent onClick={() => {}} />);
-        type _typeTests = [
+        type TypeTests = [
             Expect<Equal<ExtractProps<typeof ConnectedTestComponent>, { onClick: (arg1: any) => void }>>,
             Expect<NotEqual<ExtractProps<typeof ConnectedTestComponent>, TestComponentProps>>,
             Expect<Equal<ExtractProps<typeof ConnectedTestComponent>, Omit<TestComponentProps, "message">>>,
         ];
+        // To avoid error TS6196: 'TypeTests' is declared but never used.
+        console.log({} as TypeTests);
         done();
     });
 });

--- a/test/test_react_connect.tsx
+++ b/test/test_react_connect.tsx
@@ -5,8 +5,17 @@ import * as React from "react";
 import { Subject, Subscription, Observable, of } from "rxjs";
 import { take, skip } from "rxjs/operators";
 import { ActionMap, connect, ConnectResult, StoreProvider } from "../react";
+import { ExtractProps } from "../react/connect";
 import { Store } from "../src/index";
 import { setupJSDomEnv } from "./test_enzyme_helper";
+
+// Utilities for testing typing
+// from https://github.com/type-challenges/type-challenges/blob/master/utils/index.d.ts
+export type Expect<T extends true> = T;
+export type ExpectTrue<T extends true> = T;
+export type ExpectFalse<T extends false> = T;
+export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true;
 
 const globalClicked = new Subject<void>();
 const nextMessage = new Subject<string>();
@@ -38,7 +47,7 @@ export class TestComponent extends React.Component<TestComponentProps, {}> {
     componentDidCatch() {}
 }
 
-function getConnectedComponent(connectResultOverride?: ConnectResult<TestState, TestComponentProps> | null) {
+function getConnectedComponent(connectResultOverride?: ConnectResult<TestState, TestComponentProps, {}> | null) {
     return connect(
         TestComponent,
         (store: Store<TestState>) => {
@@ -230,7 +239,7 @@ describe("react bridge: connect() tests", () => {
             },
         );
 
-        const wrapper = mountInsideStoreProvider(<ConnectedTestComponent />);
+        const wrapper = mountInsideStoreProvider(<ConnectedTestComponent onClick={() => {}} />);
         const messageText = wrapper.find("h1").text();
         expect(messageText).to.equal("Blafoo");
     });
@@ -292,6 +301,22 @@ describe("react bridge: connect() tests", () => {
             },
         );
         console.info(ConnectedTestComponent);
+        done();
+    });
+
+    it("should not be possible to pass props that are already passed from the store", (done) => {
+        const ConnectedTestComponent = connect(TestComponent, (store: Store<TestState>) => {
+            const props = store.watch((state) => ({
+                message: state.message,
+            }));
+            return { props };
+        });
+        console.info(<ConnectedTestComponent onClick={() => {}} />);
+        type _typeTests = [
+            Expect<Equal<ExtractProps<typeof ConnectedTestComponent>, { onClick: (arg1: any) => void }>>,
+            Expect<NotEqual<ExtractProps<typeof ConnectedTestComponent>, TestComponentProps>>,
+            Expect<Equal<ExtractProps<typeof ConnectedTestComponent>, Omit<TestComponentProps, "message">>>,
+        ];
         done();
     });
 });

--- a/test/test_react_storeprovider.tsx
+++ b/test/test_react_storeprovider.tsx
@@ -88,7 +88,7 @@ describe("react bridge: StoreProvider and StoreSlice tests", () => {
                     initialState={initialSliceState}
                     cleanupState={"delete"}
                 >
-                    <ConnectedTestComponent />
+                    <ConnectedTestComponent onClick={() => {}} />
                 </StoreSlice>
             </StoreProvider>,
         );
@@ -189,9 +189,9 @@ describe("react bridge: StoreProvider and StoreSlice tests", () => {
 
         wrapper = Enzyme.mount(
             <StoreProvider store={store1}>
-                <ConnectedTestComponent />
+                <ConnectedTestComponent onClick={() => {}} />
                 <StoreProvider store={store2}>
-                    <ConnectedTestComponent />
+                    <ConnectedTestComponent onClick={() => {}} />
                 </StoreProvider>
             </StoreProvider>,
         );
@@ -220,7 +220,7 @@ describe("react bridge: StoreProvider and StoreSlice tests", () => {
         wrapper = Enzyme.mount(
             <StoreProvider store={store}>
                 <StoreSlice slice={(store: Store<TestState>) => "slice"}>
-                    <ConnectedTestComponent />
+                    <ConnectedTestComponent onClick={() => {}} message="Test" />
                 </StoreSlice>
             </StoreProvider>,
         );
@@ -244,7 +244,7 @@ describe("react bridge: StoreProvider and StoreSlice tests", () => {
         wrapper = Enzyme.mount(
             <StoreProvider store={store}>
                 <StoreSlice slice={(store: Store<TestState>) => "message"}>
-                    <ConnectedTestComponent />
+                    <ConnectedTestComponent onClick={() => {}} />
                 </StoreSlice>
             </StoreProvider>,
         );
@@ -270,7 +270,7 @@ describe("react bridge: StoreProvider and StoreSlice tests", () => {
         wrapper = Enzyme.mount(
             <StoreProvider store={store}>
                 <StoreProjection forwardProjection={forward} backwardProjection={backward}>
-                    <ConnectedTestComponent />
+                    <ConnectedTestComponent onClick={() => {}} />
                 </StoreProjection>
             </StoreProvider>,
         );


### PR DESCRIPTION
Improving on https://github.com/Dynalon/reactive-state/pull/37

I fixed the tests, it looks like because of the partial typing on the props, `onClick` and `message` were missing in a few places where they were not optional.

For some reason, `22/47` of the Function tests are failing for me on master. I had to move react and react-dom from peerDependencies (how do you run the tests, do you install React globally?) to dependencies just to be able to run the tests. Anyway, on my branch the same tests fail as on master, so I hope this doesn't introduce any other issues.

This is a little ugly but I couldn't find any other way to make the compiler happy. This is a ts error, not a lint error, so there's no way to disable it inline. Let me know if you have any suggestions.
```
        // To avoid error TS6196: 'TypeTests' is declared but never used.
        console.log({} as TypeTests);
```