### PR TITLE
chore: move istanbul to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0",
-    "istanbul": "^0.4.5",
+    "istanbul": "^0.4.5"
   },
   "dependencies": {
     "lodash.isobject": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "prettier": "^2.2.1",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack": "^5.11.0",
-    "webpack-cli": "^4.2.0"
+    "webpack-cli": "^4.2.0",
+    "istanbul": "^0.4.5",
   },
   "dependencies": {
     "lodash.isobject": "^3.0.2",
@@ -77,7 +78,6 @@
     "typescript": "^4.1.3"
   },
   "optionalDependencies": {
-    "istanbul": "^0.4.5",
     "redux": "^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Also redux could be moved to peerDependencies as it's only needed for dev tools. optionalDependencies are always installed, but can fail silently. Fixes https://github.com/Dynalon/reactive-state/issues/46